### PR TITLE
Fixes for recent issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ of each pool is migrated.
 [time travel](https://zed.brimdata.io/docs/commands/zed#15-time-travel)
 will not be possible to pre-migration commits.
 
+3. If you have a very large number of pools to migrate, the script may fail
+with a `too many open files` error. This can be addressed by increasing the
+system's hard limit on the number of file descriptors. Many references are
+available that advise how this may be done, such as
+[this article](https://docs.oracle.com/cd/E93962_01/bigData.Doc/install_onPrem/src/tins_postinstall_file_descriptors.html).
+
 We expect most users are not yet dependent on the features affected by these
 limitations. However, if your environment is severely impacted by these
 limitations, come talk to us on the

--- a/migrate.sh
+++ b/migrate.sh
@@ -64,7 +64,7 @@ for pool_ksuid in $ksuid_glob; do
     pool_order=$(zq -f text "entry.id==ksuid('$pool_ksuid') | head 1 | yield join(entry.layout.keys[0], '.') + ':' + entry.layout.order" $pools_zngs)
 
     # Look for [0-9]*.zng so snap.zng is excluded
-    branch_count=$(zq -f text 'yield entry.name | sort | uniq | count()' $pool_ksuid/branches/[0-9]*.zng)
+    branch_count=$(zq -z 'yield entry.name | sort' $pool_ksuid/branches/[0-9]*.zng | zq -f text 'uniq | count()' -)
     if [ "$branch_count" != 1 ]; then
         echo "warning: found $branch_count branches in '$pool_name' ($pool_ksuid) but only migrating 'main'"
     fi
@@ -78,13 +78,18 @@ for pool_ksuid in $ksuid_glob; do
     prior_zng=$(mktemp)
     $prior_zed -lake "$src_dir" -use "$pool_name"@main query '*' > "$prior_zng"
     zed -lake "$dst_dir" create -q -orderby "$pool_order" "$pool_name"
-    zed -lake "$dst_dir" load -q -use "$pool_name" "$prior_zng"
-    new_zng=$(mktemp)
-    zed -lake "$dst_dir" -use "$pool_name" query '*' > "$new_zng"
-    if ! cmp -s "$prior_zng" "$new_zng"; then
-        echo "error: contents of migrated pool '$pool_name' differ from original"
-        echo "pool dump before/after: $prior_zng $new_zng"
+
+    if [ -s "$prior_zng" ]; then
+        zed -lake "$dst_dir" load -q -use "$pool_name" "$prior_zng"
+        new_zng=$(mktemp)
+        zed -lake "$dst_dir" -use "$pool_name" query '*' > "$new_zng"
+        if ! cmp -s "$prior_zng" "$new_zng"; then
+            echo "error: contents of migrated pool '$pool_name' differ from original"
+            echo "pool dump before/after: $prior_zng $new_zng"
+        else
+            rm -f "$prior_zng" "$new_zng"
+        fi
     else
-        rm -f "$prior_zng" "$new_zng"
+        echo "$pool_name is empty: no data to migrate"
     fi
 done


### PR DESCRIPTION
A community zync user recently tried to migrate a large number of pools and uncovered some issues that are addressed here.

1. They hit a `too many open files` error, so I've added text to the README warning of this and pointing to an example article that advises how to raise the system limits to avoid it.

2. The part of the script that calculates the branch count was hitting a Zed issue now tracked in https://github.com/brimdata/zed/issues/4459. For now the migration script works around the issue by calling `zq` twice at that step.

3. The script was not prepared to deal with empty pools (https://github.com/brimdata/zed/issues/4460) so that's now covered.