### PR TITLE
Use find/xargs when calculating branch_count

### DIFF
--- a/migrate.sh
+++ b/migrate.sh
@@ -64,7 +64,7 @@ for pool_ksuid in $ksuid_glob; do
     pool_order=$(zq -i zng -f text "entry.id==ksuid('$pool_ksuid') | head 1 | yield join(entry.layout.keys[0], '.') + ':' + entry.layout.order" $pools_zngs)
 
     # Look for [0-9]*.zng so snap.zng is excluded
-    branch_count=$(zq -i zng -z 'yield entry.name | sort' $pool_ksuid/branches/[0-9]*.zng | zq -i zson -f text 'uniq | count()' -)
+    branch_count=$(find $pool_ksuid/branches -type f -regex "$pool_ksuid\/branches\/[0-9].*\.zng" | xargs zq -i zng - | zq -i zng -z 'yield entry.name | sort' - | zq -i zson -f text 'uniq | count()' -)
     if [ "$branch_count" != 1 ]; then
         echo "warning: found $branch_count branches in '$pool_name' ($pool_ksuid) but only migrating 'main'"
     fi

--- a/migrate.sh
+++ b/migrate.sh
@@ -64,7 +64,7 @@ for pool_ksuid in $ksuid_glob; do
     pool_order=$(zq -i zng -f text "entry.id==ksuid('$pool_ksuid') | head 1 | yield join(entry.layout.keys[0], '.') + ':' + entry.layout.order" $pools_zngs)
 
     # Look for [0-9]*.zng so snap.zng is excluded
-    branch_count=$(find $pool_ksuid/branches -type f -regex "$pool_ksuid\/branches\/[0-9].*\.zng" | xargs zq -i zng - | zq -i zng -z 'yield entry.name | sort' - | zq -i zson -f text 'uniq | count()' -)
+    branch_count=$(find $pool_ksuid/branches -name '[0-9]*.zng' | xargs cat | zq -i zng -f text 'by entry.name | count()' -)
     if [ "$branch_count" != 1 ]; then
         echo "warning: found $branch_count branches in '$pool_name' ($pool_ksuid) but only migrating 'main'"
     fi


### PR DESCRIPTION
A community zync user reported having a problem where `migrate.sh` showed a `zq: Argument list too long` error during the migration of a pool. The problem occurred because there were a very large number of files in the `branches/` directory for the pool. This PR gets around the problem by using `find` and `xargs` to concatenate the many ZNG files together into a single input stream, which Zed permits.