### PR TITLE
Use explicit "-i zng" in "zed load"

### DIFF
--- a/migrate.sh
+++ b/migrate.sh
@@ -85,7 +85,7 @@ for pool_ksuid in $ksuid_glob; do
         continue
     fi
 
-    zed -lake "$dst_dir" load -q -use "$pool_name" "$prior_zng"
+    zed -lake "$dst_dir" load -i zng -q -use "$pool_name" "$prior_zng"
     new_zng=$(mktemp)
     zed -lake "$dst_dir" -use "$pool_name" query '*' > "$new_zng"
     if ! cmp -s "$prior_zng" "$new_zng"; then


### PR DESCRIPTION
A community zync user bumped into https://github.com/brimdata/zed/issues/4586 when using the migration script. A fix is planned that would have made the auto-detect of the ZNG file input succeed, but in the meantime since ZNG input is expected here, we might as well use `-i zng` regardless.